### PR TITLE
Platform: add missing include.

### DIFF
--- a/Common/include/Common/Platform/Platform.h
+++ b/Common/include/Common/Platform/Platform.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <functional>
+#include <memory>
 #include <string>
 #include <vector>
-#include <functional>
 
 namespace rbrown::platform {
 


### PR DESCRIPTION
After removing the old toolkit abstraction and moving to platform the build fails under MSVC because of a missing include.